### PR TITLE
fix: lookup shared schemas by fully qualified name

### DIFF
--- a/public/js/schema.js
+++ b/public/js/schema.js
@@ -252,7 +252,7 @@ AvroDoc.Schema = function (avrodoc, shared_types, schema_json, filename) {
       return type;
     } else if (hasOwnPropertyS(shared_types, qualifiedNameStr)) {
       const sharedType = shared_types[qualifiedNameStr].find(
-        (sharedSchema) => sharedSchema.qualified_name === name
+        (sharedSchema) => sharedSchema.qualified_name === qualifiedNameStr
       );
 
       if (sharedType) {


### PR DESCRIPTION
Shared lookup fails in the case that two Avro records have the same namespace and the referrer defines the referent's name without using a fully qualified name. This resolves the issue by using the referent's fully qualified name for the lookup.

For example, if the referent is defined as:

```
{
  "name": "ToBeReferred",
  "type": "record",
  "namespace": "com.example_refer",
  ...
}
```

and referrer with the same namespace:

```
{
  "name": "TheReferrer",
  "doc": "A complex object referencing object from another schemata",
  "namespace": "com.example_refer",
  "type": "record",
  "fields": [
    {
      "name": "externalObject",
      "type": "ToBeReferred",
      "doc": "An object from another schemata"
    }
```

Since the type is not fully qualified, shared lookup fails. We use this shorthand abundantly in our projects, so unfortunately page load fails in current state.