### PR TITLE
feat: add support for field and type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ USAGE:
     avrodoc-plus [FLAGS] [OPTIONS] [AVRO FILES...]
 
 FLAGS:
-        --ignore-invalid     Ignore avsc files that can not be parsed as JSON (instead of quitting)
+        --ignore-invalid     Ignore avsc files that can not be parsed as JSON (instead of quiting)
 
 OPTIONS:
-    -i, --input <folder>     Pass in a source folder that will be recursively parsed and crawled for avsc files
-    -o, --output <file>      The file where the generated doc should be written to
-        --title <title>      The title that will be used in the generated HTML page, defaults to "Avrodoc".
-    -s, --style <file>       Your own less file, used to override specific style of your generated page
+    -i, --input <folder>          Pass in a source folder that will recursively parsed and crawled for avsc files
+    -o, --output <file>           The file where the generated doc should be written to
+        --title <title>           The title that will be used in the generated HTML page, defaults to "Avrodoc".
+    -s, --style <file>            Your own less file, used to override specific style of your generated page
+        --annotation-fields <f>   Comma-separated list of annotation keys to show in field tables.
+                                  Defaults to "logicalType,aliases,order".
 
 ARGS:
-    <AVRO FILES>...          If no --input is given, you can specify individual AVRO files here
+    <AVRO FILES>...          If not --input is given, you can specify individual AVRO files here
 
 EXAMPLES:
     avrodoc-plus --ignore-invalid --input ./schemas --output avrodoc.html --title "My First Avrodoc"

--- a/public/js/avrodoc.js
+++ b/public/js/avrodoc.js
@@ -6,8 +6,13 @@ dust.filters.md = function (value) {
 };
 
 // eslint-disable-next-line
-function AvroDoc(page_title, input_schemata) {
+function AvroDoc(page_title, input_schemata, options) {
   var _public = { page_title: page_title };
+  _public.annotationFields = (options && options.annotationFields) || [
+    "logicalType",
+    "aliases",
+    "order",
+  ];
   var list_pane = $("#list-pane"),
     content_pane = $("#content-pane");
   var schema_by_name = {};

--- a/public/js/schema.js
+++ b/public/js/schema.js
@@ -188,6 +188,41 @@ AvroDoc.Schema = function (avrodoc, shared_types, schema_json, filename) {
   }
 
   /**
+   * Builds a flat, filtered list of annotations for display in the field table,
+   * based on an allowlist of annotation keys. Each key is looked up on the field
+   * itself first, then on `field.type` (e.g. for logicalType).
+   *
+   * @param {object} field - a field or protocol-message parameter
+   * @param {string[]} allowedKeys - the keys to include
+   */
+  function buildTableAnnotations(field, allowedKeys) {
+    var result = [];
+    allowedKeys.forEach(function (key) {
+      var source =
+        hasOwnPropertyS(field, key) && field[key] !== undefined
+          ? field
+          : isObject(field.type) &&
+              hasOwnPropertyS(field.type, key) &&
+              field.type[key] !== undefined
+            ? field.type
+            : null;
+      if (!source) return;
+      var val = source[key];
+      var data = { key: key };
+      if (val !== null && typeof val === "object") {
+        data.complex_object = JSON.stringify(val, undefined, 3);
+      } else {
+        data.value = val;
+      }
+      result.push(data);
+    });
+    if (result.length > 0) {
+      return result;
+    }
+    return undefined;
+  }
+
+  /**
    * Takes a node in the schema tree (a JS object) and adds some fields that are
    * useful for template rendering.
    *
@@ -531,6 +566,10 @@ AvroDoc.Schema = function (avrodoc, shared_types, schema_json, filename) {
           );
           field.default_str = JSON.stringify(field["default"], null, " ");
           decorateCustomAttributes(field);
+          field.table_annotations = buildTableAnnotations(
+            field,
+            avrodoc.annotationFields,
+          );
         });
         return decorate(schema);
       } else if (schema.type === "enum") {
@@ -626,6 +665,10 @@ AvroDoc.Schema = function (avrodoc, shared_types, schema_json, filename) {
         );
         param.default_str = JSON.stringify(param["default"], null, " ");
         decorateCustomAttributes(param);
+        param.table_annotations = buildTableAnnotations(
+          param,
+          avrodoc.annotationFields,
+        );
       });
       message.response = parseSchema(
         message.response,

--- a/public/js/schema.js
+++ b/public/js/schema.js
@@ -530,6 +530,7 @@ AvroDoc.Schema = function (avrodoc, shared_types, schema_json, filename) {
             joinPath(path, field.name),
           );
           field.default_str = JSON.stringify(field["default"], null, " ");
+          decorateCustomAttributes(field);
         });
         return decorate(schema);
       } else if (schema.type === "enum") {
@@ -624,6 +625,7 @@ AvroDoc.Schema = function (avrodoc, shared_types, schema_json, filename) {
           joinPath(path, "request." + param.name),
         );
         param.default_str = JSON.stringify(param["default"], null, " ");
+        decorateCustomAttributes(param);
       });
       message.response = parseSchema(
         message.response,

--- a/src/avrodoc.js
+++ b/src/avrodoc.js
@@ -14,6 +14,7 @@ import path from "path";
  * @param {Array<string>} inputfiles an array with resolved filenames to be read and parsed and eventually added to the avrodoc
  * @param {string} outputfile the html file that should be written
  * @param {boolean} [ignoreInvalid] whether to ignore invalid JSON files
+ * @param {string[]} [annotationFields] allowlist of annotation keys to show in field tables
  * @returns {Promise<void>}
  */
 async function createAvroDoc(
@@ -22,6 +23,7 @@ async function createAvroDoc(
   inputfiles,
   outputfile,
   ignoreInvalid,
+  annotationFields,
 ) {
   console.debug(`Creating ${outputfile} from `, inputfiles);
   let schemata = inputfiles
@@ -34,6 +36,7 @@ async function createAvroDoc(
   const html = await topLevelHTML(title, extra_less_files, {
     inline: true,
     schemata,
+    annotationFields,
   });
   return await writeAvroDoc(outputfile, html);
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,10 +21,12 @@ FLAGS:
         --ignore-invalid     Ignore avsc files that can not be parsed as JSON (instead of quiting)
 
 OPTIONS:
-    -i, --input <folder>     Pass in a source folder that will recursively parsed and crawled for avsc files
-    -o, --output <file>      The file where the generated doc should be written to
-        --title <title>      The title that will be used in the generated HTML page, defaults to "Avrodoc".
-    -s, --style <file>       Your own less file, used to override specific style of your generated page
+    -i, --input <folder>          Pass in a source folder that will recursively parsed and crawled for avsc files
+    -o, --output <file>           The file where the generated doc should be written to
+        --title <title>           The title that will be used in the generated HTML page, defaults to "Avrodoc".
+    -s, --style <file>            Your own less file, used to override specific style of your generated page
+        --annotation-fields <f>   Comma-separated list of annotation keys to show in field tables.
+                                  Defaults to "logicalType,aliases,order".
 
 ARGS:
     <AVRO FILES>...          If not --input is given, you can specify individual AVRO files here
@@ -44,6 +46,7 @@ const { values: argv, positionals } = parseArgs({
     title: { type: "string" },
     style: { type: "string", short: "s" },
     "ignore-invalid": { type: "boolean", default: false },
+    "annotation-fields": { type: "string" },
   },
 });
 
@@ -69,6 +72,9 @@ const outputFile = argv.output;
 const pageTitle = argv.title;
 const extraLessFile = argv.style;
 const ignoreInvalidSchemas = Boolean(argv["ignore-invalid"]);
+const annotationFields = argv["annotation-fields"]
+  ? argv["annotation-fields"].split(",").map((f) => f.trim())
+  : undefined;
 
 if (inputFiles.length === 0) {
   console.error(
@@ -88,6 +94,7 @@ createAvroDoc(
   inputFiles,
   outputFile,
   ignoreInvalidSchemas,
+  annotationFields,
 );
 
 //private stuff

--- a/src/static_content.js
+++ b/src/static_content.js
@@ -199,6 +199,7 @@ function inlineContent(extra_less_files, callback) {
  * @param {Object} options - inline function for LESS and context options for DustJs
  * @param {boolean} [options.inline] - whether to inline CSS and JS
  * @param {any} [options.schemata] - schema data
+ * @param {string[]} [options.annotationFields] - allowlist of annotation keys shown in field tables
  * @returns {Promise<string>}
  */
 function topLevelHTML(title, extra_less_files, options) {
@@ -210,10 +211,17 @@ function topLevelHTML(title, extra_less_files, options) {
           return reject(err);
         }
 
+        /** @type {Record<string, unknown>} */
+        const avrodocOptions = {};
+        if (options.annotationFields) {
+          avrodocOptions.annotationFields = options.annotationFields;
+        }
+
         const context = {
           page_title: title ?? "Avrodoc",
           content: content,
           schemata: "[]",
+          avrodocOptions: JSON.stringify(avrodocOptions),
           ...options,
         };
 

--- a/src/top_level.dust
+++ b/src/top_level.dust
@@ -17,7 +17,7 @@
 
     <script type="text/javascript">
        jQuery(function () {
-           window.avrodoc = AvroDoc("{page_title|s}", {schemata|s});
+           window.avrodoc = AvroDoc("{page_title|s}", {schemata|s}, {avrodocOptions|s});
        });
     </script>
   </head>

--- a/templates/detail_message.dust
+++ b/templates/detail_message.dust
@@ -7,6 +7,7 @@
                 <th>Field</th>
                 <th>Default Value</th>
                 <th>Description</th>
+                <th>Annotations</th>
             </tr>
         </thead>
 
@@ -17,6 +18,24 @@
                 <td class="field">{name}</td>
                 <td class="field-doc">{default_str}</td>
                 <td class="field-doc">{doc|md|s}</td>
+                <td class="field-doc">
+                    {?annotations}
+                        <strong>Field:</strong>
+                        <ul>
+                        {#annotations}
+                            <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
+                        {/annotations}
+                        </ul>
+                    {/annotations}
+                    {?type.annotations}
+                        <strong>Type:</strong>
+                        <ul>
+                        {#type.annotations}
+                            <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
+                        {/type.annotations}
+                        </ul>
+                    {/type.annotations}
+                </td>
             </tr>
         {/request}
         </tbody>

--- a/templates/detail_message.dust
+++ b/templates/detail_message.dust
@@ -19,22 +19,13 @@
                 <td class="field-doc">{default_str}</td>
                 <td class="field-doc">{doc|md|s}</td>
                 <td class="field-doc">
-                    {?annotations}
-                        <strong>Field:</strong>
+                    {?table_annotations}
                         <ul>
-                        {#annotations}
+                        {#table_annotations}
                             <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
-                        {/annotations}
+                        {/table_annotations}
                         </ul>
-                    {/annotations}
-                    {?type.annotations}
-                        <strong>Type:</strong>
-                        <ul>
-                        {#type.annotations}
-                            <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
-                        {/type.annotations}
-                        </ul>
-                    {/type.annotations}
+                    {/table_annotations}
                 </td>
             </tr>
         {/request}

--- a/templates/detail_record.dust
+++ b/templates/detail_record.dust
@@ -19,22 +19,13 @@
                 <td class="field-doc">{default_str}</td>
                 <td class="field-doc">{.doc|md|s}</td>
                 <td class="field-doc">
-                    {?annotations}
-                        <strong>Field:</strong>
+                    {?table_annotations}
                         <ul>
-                        {#annotations}
+                        {#table_annotations}
                             <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
-                        {/annotations}
+                        {/table_annotations}
                         </ul>
-                    {/annotations}
-                    {?type.annotations}
-                        <strong>Type:</strong>
-                        <ul>
-                        {#type.annotations}
-                            <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
-                        {/type.annotations}
-                        </ul>
-                    {/type.annotations}
+                    {/table_annotations}
                 </td>
             </tr>
         {/fields}

--- a/templates/detail_record.dust
+++ b/templates/detail_record.dust
@@ -7,6 +7,7 @@
                 <th>Field</th>
                 <th>Default Value</th>
                 <th>Description</th>
+                <th>Annotations</th>
             </tr>
         </thead>
 
@@ -17,6 +18,24 @@
                 <td class="field">{name}{?order} <span class="label">{order}</span>{/order}</td>
                 <td class="field-doc">{default_str}</td>
                 <td class="field-doc">{.doc|md|s}</td>
+                <td class="field-doc">
+                    {?annotations}
+                        <strong>Field:</strong>
+                        <ul>
+                        {#annotations}
+                            <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
+                        {/annotations}
+                        </ul>
+                    {/annotations}
+                    {?type.annotations}
+                        <strong>Type:</strong>
+                        <ul>
+                        {#type.annotations}
+                            <li><code>{key}</code>: {#complex_object}<pre>{.}</pre>{:else}{value}{/complex_object}</li>
+                        {/type.annotations}
+                        </ul>
+                    {/type.annotations}
+                </td>
             </tr>
         {/fields}
         </tbody>


### PR DESCRIPTION
Display field-level and type-level annotations (e.g., logicalType) in generated documentation. Annotations now appear in a dedicated column in field tables for both records and protocol messages.

Closes #13 