### PR TITLE
fix: dismiss popover on navigation and restore scroll on browser back

### DIFF
--- a/public/js/avrodoc.js
+++ b/public/js/avrodoc.js
@@ -25,6 +25,17 @@ function AvroDoc() {
   var activeTrigger = null;
   var activeTip = null;
 
+  function dismissActivePopover() {
+    clearTimeout(showTimer);
+    clearTimeout(hideTimer);
+    if (activePopover) {
+      activePopover.hide();
+      activePopover = null;
+      activeTrigger = null;
+      activeTip = null;
+    }
+  }
+
   function scheduleHide() {
     clearTimeout(showTimer);
     clearTimeout(hideTimer);
@@ -119,7 +130,7 @@ function AvroDoc() {
     return null;
   }
 
-  function handleRoute() {
+  function handleRoute(savedScrollY) {
     var hash = window.location.hash || "#/";
     var section = findSection(hash);
     if (!section) {
@@ -130,13 +141,38 @@ function AvroDoc() {
       s.hidden = true;
     });
     section.hidden = false;
-    document.body.scrollTop = 0;
-    document.documentElement.scrollTop = 0;
+    if (savedScrollY !== undefined) {
+      window.scrollTo(0, savedScrollY);
+    } else {
+      document.body.scrollTop = 0;
+      document.documentElement.scrollTop = 0;
+    }
     updateSidebarSelection(hash);
     setupPopovers();
   }
 
-  window.addEventListener("hashchange", handleRoute);
+  var scrollPositions = {};
+  var isBackForward = false;
+
+  window.addEventListener("popstate", function () {
+    isBackForward = true;
+  });
+
+  window.addEventListener("hashchange", function (e) {
+    var oldHash = e.oldURL ? new URL(e.oldURL).hash || "#/" : "#/";
+    scrollPositions[oldHash] =
+      document.documentElement.scrollTop || document.body.scrollTop || 0;
+
+    dismissActivePopover();
+
+    var restoredScroll;
+    if (isBackForward) {
+      restoredScroll = scrollPositions[window.location.hash || "#/"];
+    }
+    isBackForward = false;
+
+    handleRoute(restoredScroll);
+  });
 
   document.addEventListener("DOMContentLoaded", function () {
     loadPopoverData();


### PR DESCRIPTION
Two UX fixes for the SSR rewrite.

## Fix 1: Popover persists after clicking a hovered link

The active popover was never dismissed on navigation. Added a `dismissActivePopover()` helper that is called in the `hashchange` listener, so the popover is torn down immediately regardless of how navigation was triggered (clicking the hovered link, a sidebar link, keyboard, etc.).

## Fix 2: Scroll position not restored on browser back button

`handleRoute()` previously always reset scroll to the top. For back/forward navigation the user expected to land back where they were.

**Approach:**
- `scrollPositions` map saves the scroll offset for each hash before navigating away (captured in the `hashchange` handler from `e.oldURL`)
- A `popstate` listener sets a flag — `popstate` fires on back/forward but not on link clicks — so `hashchange` can tell the difference
- On back/forward: `handleRoute` is passed the saved offset and calls `window.scrollTo`
- On forward navigation: behaviour unchanged, page scrolls to top